### PR TITLE
Audio Editor bug fixes + extra

### DIFF
--- a/MH-Engine/Audio/AudioEditor.cpp
+++ b/MH-Engine/Audio/AudioEditor.cpp
@@ -192,6 +192,7 @@ void AudioEditor::SpawnControlWindow()
 			{
 				if (soundBankToLoad) {
 					// Unload audio from audio engine
+					AudioEngine::GetInstance()->StopAllAudio();
 					if (previousSoundBankFileIdx > -1) {
 						for (unsigned int i = 0; i < m_vSoundFileInfo.size(); i++) {
 							AudioEngine::GetInstance()->UnloadAudio(AudioEngine::GetInstance()->GetFileName(m_vSoundFileInfo[i].filePath), (AudioType)m_vSoundFileInfo[i].audioType);
@@ -233,12 +234,39 @@ void AudioEditor::SpawnControlWindow()
 					if (ImGui::Button(std::string("Add SFX##Add Sound to SFX Sound Bank").c_str())) {
 						if (FileLoading::OpenFileExplorer(m_sSelectedFile, m_sFilePath))
 						{
+							bool isNew = true;
 							JSONSoundFile newSound;
-							newSound.filePath = SOUND_FILES_PATH + m_sSelectedFile;
-							newSound.volume = 1.0f;
-							newSound.audioType = SFX;
-							m_vSoundFileInfo.emplace_back(newSound);
-							AudioEngine::GetInstance()->LoadAudio(StringHelper::StringToWide(newSound.filePath), newSound.volume, (AudioType)newSound.audioType);
+							std::filesystem::path path(StringHelper::StringToWide(m_sSelectedFile));
+							std::string selectedFilePath = StringHelper::StringToNarrow(path.extension());
+
+							//fileExtension.extension();
+
+							if (selectedFilePath == ".wav") {
+								// not working
+								
+								std::filesystem::path fileName(StringHelper::StringToWide(m_sSelectedFile));
+								selectedFilePath = StringHelper::StringToNarrow(fileName);
+
+
+								newSound.name = selectedFilePath;
+								newSound.filePath = SOUND_FILES_PATH + m_sSelectedFile;
+								newSound.volume = 1.0f;
+								newSound.audioType = SFX;
+
+								for (unsigned int i = 0; i < m_vSoundFileInfo.size(); i++) {
+									if (m_vSoundFileInfo[i].name == newSound.name) {
+										isNew = false;
+									}
+								}
+
+								if (isNew) {
+									m_vSoundFileInfo.emplace_back(newSound);
+									AudioEngine::GetInstance()->LoadAudio(StringHelper::StringToWide(newSound.filePath), newSound.volume, (AudioType)newSound.audioType);
+								}
+							}
+							else {
+								ErrorLogger::Log("AudioEditor::SpawnControlWindow: Invalid file format chosen to load into the Sound Bank");
+							}
 						}
 					}
 
@@ -257,7 +285,7 @@ void AudioEditor::SpawnControlWindow()
 										AudioEngine::GetInstance()->PlayAudio(AudioEngine::GetInstance()->GetFileName(m_vSoundFileInfo[i].filePath), MUSIC);
 									}
 									ImGui::SameLine();
-									if (ImGui::Button(std::string("Unpause##").append(std::to_string(i)).append("Unpause").c_str())) {
+									if (ImGui::Button(std::string("Unpause##").append(std::to_string(i)).append("unpause").c_str())) {
 										AudioEngine::GetInstance()->UnpauseMusic();
 									}
 									ImGui::SameLine();
@@ -285,12 +313,25 @@ void AudioEditor::SpawnControlWindow()
 					if (ImGui::Button(std::string("Add Music##Add Sound to Music Sound Bank").c_str())) {
 						if (FileLoading::OpenFileExplorer(m_sSelectedFile, m_sFilePath))
 						{
+							bool isNew = true;
 							JSONSoundFile newSound;
+							std::filesystem::path fileName(StringHelper::StringToWide(m_sSelectedFile));
+							fileName.stem();
+							newSound.name = StringHelper::StringToNarrow(fileName);
 							newSound.filePath = SOUND_FILES_PATH + m_sSelectedFile;
 							newSound.volume = 1.0f;
 							newSound.audioType = MUSIC;
-							m_vSoundFileInfo.emplace_back(newSound);
-							AudioEngine::GetInstance()->LoadAudio(StringHelper::StringToWide(newSound.filePath), newSound.volume, (AudioType)newSound.audioType);
+
+							for (unsigned int i = 0; i < m_vSoundFileInfo.size(); i++) {
+								if (m_vSoundFileInfo[i].name == newSound.name) {
+									isNew = false;
+								}
+							}
+
+							if (isNew) {
+								m_vSoundFileInfo.emplace_back(newSound);
+								AudioEngine::GetInstance()->LoadAudio(StringHelper::StringToWide(newSound.filePath), newSound.volume, (AudioType)newSound.audioType);
+							}
 						}
 					}
 

--- a/MH-Engine/Audio/AudioEditor.cpp
+++ b/MH-Engine/Audio/AudioEditor.cpp
@@ -237,18 +237,14 @@ void AudioEditor::SpawnControlWindow()
 							bool isNew = true;
 							JSONSoundFile newSound;
 							std::filesystem::path path(StringHelper::StringToWide(m_sSelectedFile));
-							std::string selectedFilePath = StringHelper::StringToNarrow(path.extension());
+							std::string selectedFile = StringHelper::StringToNarrow(path.extension());
 
 							//fileExtension.extension();
 
-							if (selectedFilePath == ".wav") {
-								// not working
-								
+							if (selectedFile == ".wav") {
 								std::filesystem::path fileName(StringHelper::StringToWide(m_sSelectedFile));
-								selectedFilePath = StringHelper::StringToNarrow(fileName);
-
-
-								newSound.name = selectedFilePath;
+								selectedFile = StringHelper::StringToNarrow(fileName.stem());
+								newSound.name = selectedFile;
 								newSound.filePath = SOUND_FILES_PATH + m_sSelectedFile;
 								newSound.volume = 1.0f;
 								newSound.audioType = SFX;
@@ -315,16 +311,23 @@ void AudioEditor::SpawnControlWindow()
 						{
 							bool isNew = true;
 							JSONSoundFile newSound;
-							std::filesystem::path fileName(StringHelper::StringToWide(m_sSelectedFile));
-							fileName.stem();
-							newSound.name = StringHelper::StringToNarrow(fileName);
-							newSound.filePath = SOUND_FILES_PATH + m_sSelectedFile;
-							newSound.volume = 1.0f;
-							newSound.audioType = MUSIC;
+							std::filesystem::path path(StringHelper::StringToWide(m_sSelectedFile));
+							std::string selectedFile = StringHelper::StringToNarrow(path.extension());
 
-							for (unsigned int i = 0; i < m_vSoundFileInfo.size(); i++) {
-								if (m_vSoundFileInfo[i].name == newSound.name) {
-									isNew = false;
+							//fileExtension.extension();
+
+							if (selectedFile == ".wav") {
+								std::filesystem::path fileName(StringHelper::StringToWide(m_sSelectedFile));
+								selectedFile = StringHelper::StringToNarrow(fileName.stem());
+								newSound.name = selectedFile;
+								newSound.filePath = SOUND_FILES_PATH + m_sSelectedFile;
+								newSound.volume = 1.0f;
+								newSound.audioType = MUSIC;
+
+								for (unsigned int i = 0; i < m_vSoundFileInfo.size(); i++) {
+									if (m_vSoundFileInfo[i].name == newSound.name) {
+										isNew = false;
+									}
 								}
 							}
 

--- a/MH-Engine/Audio/AudioEditor.h
+++ b/MH-Engine/Audio/AudioEditor.h
@@ -24,10 +24,11 @@ public:
 	void SaveToFileSoundBankLists();
 	void LoadFromFileSoundBankLists();
 	//void SaveToFileSoundBankFiles();
-
+	
 	// sound bank handle
 	void LoadSoundFileInfoFromJSON(std::string loadFilePath);
 	void SaveSoundFileInfoToJSON(std::string fileName);
+
 #endif // _DEBUG
 private:
 	std::string m_sFilePath;

--- a/MH-Engine/Audio/AudioEngine.cpp
+++ b/MH-Engine/Audio/AudioEngine.cpp
@@ -77,13 +77,16 @@ void AudioEngine::LoadAudioFromJSON(std::string loadFilePath)
 void AudioEngine::SaveAudioToJSON(std::vector<SoundBankFile*>* sfxSoundList, std::vector<SoundBankFile*>* musicSoundList, std::string fileName)
 {
 	std::vector<JSONSoundFile> soundFileList;
+	std::string name;
 
 	for (int i = 0; sfxSoundList->size() > i; i++) {
-		soundFileList.push_back({ "Resources\\Audio\\" + StringHelper::StringToNarrow(sfxSoundList->at(i)->fileName) + ".wav", sfxSoundList->at(i)->volume, 0 });
+		name = StringHelper::StringToNarrow(sfxSoundList->at(i)->fileName);
+		soundFileList.push_back({ name, "Resources\\Audio\\" + name + ".wav", sfxSoundList->at(i)->volume, 0 });
 	}
 
 	for (int i = 0; musicSoundList->size() > i; i++) {
-		soundFileList.push_back({ "Resources\\Audio\\" + StringHelper::StringToNarrow(musicSoundList->at(i)->fileName) + ".wav", musicSoundList->at(i)->volume, 1 });
+		name = StringHelper::StringToNarrow(musicSoundList->at(i)->fileName);
+		soundFileList.push_back({ name, "Resources\\Audio\\" + name + ".wav", musicSoundList->at(i)->volume, 1 });
 	}
 
 	JsonLoading::SaveJson(soundFileList, "Resources\\Audio\\Sound Banks\\" + fileName + ".json");
@@ -288,6 +291,19 @@ HRESULT AudioEngine::UnloadAudio(std::wstring fileName, AudioType audioType)
 	}
 
 	return hr;
+}
+
+void AudioEngine::StopAllAudio()
+{
+	for (int i = 0; m_vSFXSourceVoiceList->size() > i; i++) {
+		m_vSFXSourceVoiceList->at(i)->DestroyVoice();
+		m_vSFXSourceVoiceList->erase(m_vSFXSourceVoiceList->begin() + i);
+	}
+
+	for (int i = 0; m_vMusicSourceVoiceList->size() > i; i++) {
+		m_vMusicSourceVoiceList->at(i)->DestroyVoice();
+		m_vMusicSourceVoiceList->erase(m_vMusicSourceVoiceList->begin() + i);
+	}
 }
 
 HRESULT AudioEngine::FindChunk(HANDLE hFile, DWORD fourcc, DWORD& dwChunkSize, DWORD& dwChunkDataPosition)

--- a/MH-Engine/Audio/AudioEngine.h
+++ b/MH-Engine/Audio/AudioEngine.h
@@ -41,11 +41,12 @@ struct SoundBankFile
 };
 
 struct JSONSoundFile {
+	std::string name;
 	std::string filePath;
 	float volume;
 	int audioType;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(JSONSoundFile, filePath, volume, audioType);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(JSONSoundFile, name, filePath, volume, audioType);
 
 enum AudioType
 {
@@ -76,6 +77,7 @@ public:
 	HRESULT PauseMusic(); // Pauses ALL music
 	HRESULT StopMusic(); // Stops ALL music and removes it from music source voice list
 	HRESULT UnloadAudio(std::wstring fileName, AudioType audioType); // Unloading audio from sound bank list
+	void StopAllAudio();
 
 	//// Loading Audio stuff
 	HRESULT FindChunk(HANDLE hFile, DWORD fourcc, DWORD& dwChunkSize, DWORD& dwChunkDataPosition);

--- a/MH-Engine/Resources/Audio/Sound Banks/SoundBank1.json
+++ b/MH-Engine/Resources/Audio/Sound Banks/SoundBank1.json
@@ -1,35 +1,42 @@
 [
     {
+		"name": "pcm-32bit-44khz-mono",
         "audioType": 0,
         "filePath": "Resources\\Audio\\pcm-32bit-44khz-mono.wav",
         "volume": 1.0
     },
     {
+		"name": "pcm-32bit-44khz-stereo",		
         "audioType": 0,
         "filePath": "Resources\\Audio\\pcm-32bit-44khz-stereo.wav",
         "volume": 1.0
     },
     {
+		"name": "piano2",
         "audioType": 0,
         "filePath": "Resources\\Audio\\piano2.wav",
         "volume": 1.0
     },
     {
+		"name": "quietlaugh",
         "audioType": 0,
         "filePath": "Resources\\Audio\\quietlaugh.wav",
         "volume": 1.0
     },
     {
+		"name": "bullettest",
         "audioType": 0,
         "filePath": "Resources\\Audio\\bullettest.wav",
         "volume": 1.0
     },
     {
+		"name": "creepymusic",
         "audioType": 1,
         "filePath": "Resources\\Audio\\creepymusic.wav",
         "volume": 1.0
     },
     {
+		"name": "partymusic",
         "audioType": 1,
         "filePath": "Resources\\Audio\\partymusic.wav",
         "volume": 1.0

--- a/MH-Engine/Resources/Audio/Sound Banks/SoundBank2.json
+++ b/MH-Engine/Resources/Audio/Sound Banks/SoundBank2.json
@@ -1,35 +1,42 @@
 [
     {
+		"name": "pcm-32bit-44khz-mono",
         "audioType": 0,
         "filePath": "Resources\\Audio\\pcm-32bit-44khz-mono.wav",
         "volume": 1.0
     },
     {
+		"name": "pcm-32bit-44khz-stereo",		
         "audioType": 0,
         "filePath": "Resources\\Audio\\pcm-32bit-44khz-stereo.wav",
         "volume": 1.0
     },
     {
+		"name": "piano2",
         "audioType": 0,
         "filePath": "Resources\\Audio\\piano2.wav",
         "volume": 1.0
     },
     {
+		"name": "quietlaugh",
         "audioType": 0,
         "filePath": "Resources\\Audio\\quietlaugh.wav",
         "volume": 1.0
     },
     {
+		"name": "bullettest",
         "audioType": 0,
         "filePath": "Resources\\Audio\\bullettest.wav",
         "volume": 1.0
     },
     {
+		"name": "creepymusic",
         "audioType": 1,
         "filePath": "Resources\\Audio\\creepymusic.wav",
         "volume": 1.0
     },
     {
+		"name": "partymusic",
         "audioType": 1,
         "filePath": "Resources\\Audio\\partymusic.wav",
         "volume": 1.0

--- a/MH-Engine/Resources/Audio/Sound Banks/SoundBank3.json
+++ b/MH-Engine/Resources/Audio/Sound Banks/SoundBank3.json
@@ -1,35 +1,42 @@
 [
     {
+		"name": "pcm-32bit-44khz-mono",
         "audioType": 0,
         "filePath": "Resources\\Audio\\pcm-32bit-44khz-mono.wav",
         "volume": 1.0
     },
     {
+		"name": "pcm-32bit-44khz-stereo",		
         "audioType": 0,
         "filePath": "Resources\\Audio\\pcm-32bit-44khz-stereo.wav",
         "volume": 1.0
     },
     {
+		"name": "piano2",
         "audioType": 0,
         "filePath": "Resources\\Audio\\piano2.wav",
         "volume": 1.0
     },
     {
+		"name": "quietlaugh",
         "audioType": 0,
         "filePath": "Resources\\Audio\\quietlaugh.wav",
         "volume": 1.0
     },
     {
+		"name": "bullettest",
         "audioType": 0,
         "filePath": "Resources\\Audio\\bullettest.wav",
         "volume": 1.0
     },
     {
+		"name": "creepymusic",
         "audioType": 1,
         "filePath": "Resources\\Audio\\creepymusic.wav",
         "volume": 1.0
     },
     {
+		"name": "partymusic",
         "audioType": 1,
         "filePath": "Resources\\Audio\\partymusic.wav",
         "volume": 1.0

--- a/MH-Engine/Resources/Audio/Sound Banks/SoundBank4.json
+++ b/MH-Engine/Resources/Audio/Sound Banks/SoundBank4.json
@@ -1,7 +1,44 @@
 [
     {
+		"name": "pcm-32bit-44khz-mono",
+        "audioType": 0,
+        "filePath": "Resources\\Audio\\pcm-32bit-44khz-mono.wav",
+        "volume": 1.0
+    },
+    {
+		"name": "pcm-32bit-44khz-stereo",		
+        "audioType": 0,
+        "filePath": "Resources\\Audio\\pcm-32bit-44khz-stereo.wav",
+        "volume": 1.0
+    },
+    {
+		"name": "piano2",
+        "audioType": 0,
+        "filePath": "Resources\\Audio\\piano2.wav",
+        "volume": 1.0
+    },
+    {
+		"name": "quietlaugh",
+        "audioType": 0,
+        "filePath": "Resources\\Audio\\quietlaugh.wav",
+        "volume": 1.0
+    },
+    {
+		"name": "bullettest",
         "audioType": 0,
         "filePath": "Resources\\Audio\\bullettest.wav",
-        "volume": 0.375
+        "volume": 1.0
+    },
+    {
+		"name": "creepymusic",
+        "audioType": 1,
+        "filePath": "Resources\\Audio\\creepymusic.wav",
+        "volume": 1.0
+    },
+    {
+		"name": "partymusic",
+        "audioType": 1,
+        "filePath": "Resources\\Audio\\partymusic.wav",
+        "volume": 1.0
     }
 ]


### PR DESCRIPTION
**Describe your changes**
- Now duplicate sounds that are being loaded into the sound bank are not allowed (it won't load them)
- Additionally it checks whether file that user is trying to open is of *.wav format (it will throw an error if that's invalid format and won't load it)
- Fixes changing sound bank during playback of any sound causing crashes/playing noise
- Created helper function in audio engine to stop all audio (destroys all source voices)

**Screenshots**
N/A

**Additional context**
These are the known bugs so far outside broken functionality of adding/creating/loading new sound banks. These are an another issue though.