### PR TITLE
The tileMap loading in Level is now readable and more efficient

### DIFF
--- a/MH-Engine/Levels/Level1.h
+++ b/MH-Engine/Levels/Level1.h
@@ -44,9 +44,12 @@ public:
 private:
 	// Tile Map
 	void OnCreateTileMap();
-	void OnCreateTileMapDraw(std::vector<TileMapDraw>& tileMapDraw);
-	void UpdateTileMap(const float dt, std::vector<TileMapDraw>& tileMapDraw, TileMapLayer tileMapLayer);
-	void RenderFrameTileMap(std::vector<TileMapDraw>& tileMapDraw);
+	void OnCreateTileMapDraw();
+	void UpdateTileMap(const float dt);
+	void UpdateBothTileMaps(const float dt);
+	void UpdateTileMapTexture(const float dt);
+	void UpdateTileMapEmpty(const float dt);
+	void RenderFrameTileMap();
 
 	void OnCreateEntity();
 	void RenderFrameEntity();
@@ -74,11 +77,14 @@ private:
 	TextRenderer m_textRenderer;
 	TileMapEditor* m_tileMapEditor;
 	TileMapLoader* m_tileMapLoader;
-	std::vector<TileMapDraw> m_tileMapDrawBackground;
-	std::vector<TileMapDraw> m_tileMapDrawForeground;
+	std::vector<std::vector<TileMapDraw>> m_tileMapDrawLayers;
+	const int m_iTileMapLayers = 2;
+
 	std::shared_ptr<ProjectileEditor> m_projectileEditor;
 
 	const int m_iTileSize = 32;
+
+	bool m_bMapUpdate = true;
 };
 
 #endif

--- a/MH-Engine/TileMap/TileMapEditor.cpp
+++ b/MH-Engine/TileMap/TileMapEditor.cpp
@@ -25,8 +25,9 @@ TileMapEditor::TileMapEditor(int rows, int columns)
 	m_sCurrentSelectedTileType = "Current Tile Type: ";
 	m_sCurrentSelectedTileType += m_sTileTypeData[0].name;
 
-	m_bDrawOnce = false;
+	m_bDrawOnce = true;
 	m_bDrawContinuous = false;
+	m_bLayerSwitched = true;
 
 	m_tileMapLayer = TileMapLayer::Background;
 }
@@ -58,19 +59,39 @@ void TileMapEditor::SpawnControlWindow()
 }
 #endif
 
-bool TileMapEditor::UpdateDrawOnceAvalible()
+bool TileMapEditor::IsDrawOnceAvalible()
 {
 	return m_bDrawOnce;
 }
 
-void TileMapEditor::UpdateDrawOnceDone()
+void TileMapEditor::SetDrawOnceDone()
 {
 	m_bDrawOnce = false;
 }
 
-void TileMapEditor::UpdateMapDrawn()
+void TileMapEditor::SetMapDrawnDone()
 {
 	m_bMapUpdated = false;
+}
+
+void TileMapEditor::SetLayerSwitchedDone()
+{
+	m_bLayerSwitched = false;
+}
+
+void TileMapEditor::SetLoadedFileDone()
+{
+	m_bLoadedFile = false;
+}
+
+std::vector<int> TileMapEditor::GetUpdatedTileMapTiles()
+{
+	return m_iUpdatedTileMapTiles;
+}
+
+void TileMapEditor::SetClearUpdatedTileMapTiles()
+{
+	m_iUpdatedTileMapTiles.clear();
 }
 
 TileMap* TileMapEditor::GetLevel(TileMapLayer layer)
@@ -85,9 +106,19 @@ TileMap* TileMapEditor::GetLevel(TileMapLayer layer)
 	}
 }
 
-bool TileMapEditor::UpdateDrawContinuousAvalible()
+bool TileMapEditor::IsDrawContinuousAvalible()
 {
 	return m_bDrawContinuous && m_bMapUpdated;	
+}
+
+bool TileMapEditor::IsLayerSwitched()
+{
+	return m_bLayerSwitched;
+}
+
+bool TileMapEditor::IsLoadedFile()
+{
+	return m_bLoadedFile;
 }
 
 void TileMapEditor::DrawButton()
@@ -116,7 +147,11 @@ void TileMapEditor::Load()
 		{
 			if (FileLoading::OpenFileExplorer(m_sSelectedFile, m_sFilePath))
 			{
-				if (!LoadProcessFile())
+				if (LoadProcessFile())
+				{
+					m_bLoadedFile = true;
+				}
+				else
 				{
 					m_sSelectedFile = "Load Process Failed";
 				}
@@ -360,6 +395,7 @@ void TileMapEditor::UpdateSingleTileMapGridPreview()
 			if (m_bTileMapPreviewImageButton[i])
 			{
 				m_bMapUpdated = true;
+				m_iUpdatedTileMapTiles.push_back(i);
 				for (int j = 0; j < m_iSizeOfTileTypeData; j++)
 				{
 					if (m_iCurrentSelectedTileType == m_tileMapBackground->GetTileTypeData()[j].type)
@@ -447,6 +483,7 @@ void TileMapEditor::SelectTileMapLayer()
 			m_tileMapLayer = TileMapLayer::Both;
 		}
 		m_bMapUpdated = true;
+		m_bLayerSwitched = true;
 	}
 #endif
 }
@@ -454,4 +491,30 @@ void TileMapEditor::SelectTileMapLayer()
 TileMapLayer TileMapEditor::GetTileMapLayer()
 {
 	return m_tileMapLayer;
+}
+
+int TileMapEditor::GetTileMapLayerInt()
+{
+	if (m_tileMapLayer == TileMapLayer::Background)
+	{
+		return 0;
+	}
+	else if (m_tileMapLayer == TileMapLayer::Foreground)
+	{
+		return 1;
+	}
+	return 2;
+}
+
+int TileMapEditor::GetTileMapOtherLayerInt()
+{
+	if (m_tileMapLayer == TileMapLayer::Background)
+	{
+		return 1;
+	}
+	else if (m_tileMapLayer == TileMapLayer::Foreground)
+	{
+		return 0;
+	}
+	return 2;
 }

--- a/MH-Engine/TileMap/TileMapEditor.h
+++ b/MH-Engine/TileMap/TileMapEditor.h
@@ -23,14 +23,24 @@ public:
 	void SpawnControlWindow();
 #endif
 
-	bool UpdateDrawOnceAvalible();
-	bool UpdateDrawContinuousAvalible();
-	void UpdateDrawOnceDone();
-	void UpdateMapDrawn();
+	bool IsDrawOnceAvalible();
+	bool IsDrawContinuousAvalible();
+	bool IsLayerSwitched();
+	bool IsLoadedFile();
+
+	void SetDrawOnceDone();
+	void SetMapDrawnDone();
+	void SetLayerSwitchedDone();
+	void SetLoadedFileDone();
+
+	std::vector<int> GetUpdatedTileMapTiles();
+	void SetClearUpdatedTileMapTiles();
 
 	TileMap* GetLevel(TileMapLayer layer);
 
 	TileMapLayer GetTileMapLayer();
+	int GetTileMapLayerInt();
+	int GetTileMapOtherLayerInt();
 private:
 	void Load();
 	bool LoadProcessFile();
@@ -66,11 +76,15 @@ private:
 	bool m_bDrawOnce;
 	bool m_bDrawContinuous;
 	bool m_bMapUpdated;
+	bool m_bLayerSwitched;
+	bool m_bLoadedFile;
 
 	std::vector<bool> m_bTileMapPreviewImageButton;
 
 	int m_iRows;
 	int m_iColumns;
+
+	std::vector<int> m_iUpdatedTileMapTiles;
 
 #if _DEBUG
 	std::vector<ImColor> m_TileMapPreviewImageButtonColor;

--- a/MH-Engine/TileMap/TileMapLoader.cpp
+++ b/MH-Engine/TileMap/TileMapLoader.cpp
@@ -44,13 +44,13 @@ void TileMapLoader::LoadLevel(std::string filePathBackground, std::string filePa
 	m_sTileTypeData = m_tileMapBackground->GetTileTypeData();
 }
 
-std::string TileMapLoader::GetTileTypeName(int pos, TileMapLayer tileMapLayer)
+std::string TileMapLoader::GetTileTypeName(int tileMapLayer, int pos)
 {
-	if (tileMapLayer == TileMapLayer::Background)
+	if (tileMapLayer == 0)
 	{
 		return m_sTileTypeData[m_tileMapBackground->GetTileType(pos)].name;
 	}
-	else if (tileMapLayer == TileMapLayer::Foreground)
+	else if (tileMapLayer == 1)
 	{
 		return m_sTileTypeData[m_tileMapForeground->GetTileType(pos)].name;
 	}

--- a/MH-Engine/TileMap/TileMapLoader.h
+++ b/MH-Engine/TileMap/TileMapLoader.h
@@ -7,10 +7,6 @@ using json = nlohmann::json;
 #include "JsonLoading.h"
 #include "TileMap.h"
 
-#if _DEBUG
-#include <imgui/imgui.h>
-#endif
-
 //#define COLUMNS 40
 //#define ROWS 22
 
@@ -24,7 +20,7 @@ public:
 
 	void LoadLevel(std::string filePathBackground, std::string filePathForeground);
 
-	std::string GetTileTypeName(int pos, TileMapLayer tileMapLayer);
+	std::string GetTileTypeName(int tileMapLayer, int pos);
 
 private:
 	int m_iRows;
@@ -38,7 +34,5 @@ private:
 
 	std::vector<TileTypeData> m_sTileTypeData;
 };
-
-
 
 #endif


### PR DESCRIPTION
**Describe your changes**
Code is more readable, fixed bug where it would only update the last tile you changed when you clicked draw, now stores the edited ready to be drawn tiles.
Both the foreground and background layers are now one vector vector

**Screenshots**
If applicable, add screenshots to help explain your changes.

**Additional context**
Add any other context about your changes here.
